### PR TITLE
Add SqliteKV key-value store and tests

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Core package for the personal AI assistant."""

--- a/src/db.py
+++ b/src/db.py
@@ -27,6 +27,18 @@ class SqliteKV:
         self.conn.commit()
         self._ensure_seed()
 
+    def __enter__(self) -> "SqliteKV":
+        """Enter the runtime context related to this object."""
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        """Close the connection when leaving the context."""
+        self.close()
+
+    def close(self) -> None:
+        """Close the underlying SQLite connection."""
+        self.conn.close()
+
     def _ensure_seed(self) -> None:
         """Insert the default ``last_history_id`` row if missing."""
         cur = self.conn.cursor()

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,59 @@
+"""Simple SQLite-based key-value store for application state."""
+
+import sqlite3
+from typing import Optional
+
+
+class SqliteKV:
+    """Key-value storage backed by an SQLite database."""
+
+    def __init__(self, db_path: str = "assistant.db") -> None:
+        """Create or connect to the SQLite database and ensure schema.
+
+        Parameters
+        ----------
+        db_path: str, optional
+            Path to the SQLite database file. Defaults to ``"assistant.db"``.
+        """
+        self.conn = sqlite3.connect(db_path)
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS state(
+              key TEXT PRIMARY KEY,
+              value TEXT
+            );
+            """
+        )
+        self.conn.commit()
+        self._ensure_seed()
+
+    def _ensure_seed(self) -> None:
+        """Insert the default ``last_history_id`` row if missing."""
+        cur = self.conn.cursor()
+        cur.execute("SELECT value FROM state WHERE key=?", ("last_history_id",))
+        row = cur.fetchone()
+        if row is None:
+            cur.execute(
+                "INSERT INTO state(key, value) VALUES(?, ?)",
+                ("last_history_id", "0"),
+            )
+            self.conn.commit()
+        cur.close()
+
+    def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
+        """Retrieve the value for ``key`` from the store."""
+        cur = self.conn.cursor()
+        cur.execute("SELECT value FROM state WHERE key=?", (key,))
+        row = cur.fetchone()
+        cur.close()
+        if row is None:
+            return default
+        return row[0]
+
+    def set(self, key: str, value: str) -> None:
+        """Store ``value`` for ``key`` in the database."""
+        self.conn.execute(
+            "REPLACE INTO state(key, value) VALUES(?, ?)",
+            (key, value),
+        )
+        self.conn.commit()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -8,22 +8,20 @@ from src.db import SqliteKV
 
 def test_set_get(tmp_path):
     db_file = tmp_path / "assistant.db"
-    kv = SqliteKV(str(db_file))
+    with SqliteKV(str(db_file)) as kv:
+        # Ensure seed value is created
+        assert kv.get("last_history_id") == "0"
 
-    # Ensure seed value is created
-    assert kv.get("last_history_id") == "0"
-
-    kv.set("foo", "bar")
-    assert kv.get("foo") == "bar"
-    assert kv.get("missing", "default") == "default"
+        kv.set("foo", "bar")
+        assert kv.get("foo") == "bar"
+        assert kv.get("missing", "default") == "default"
 
 
 def test_set_many(tmp_path):
     db_file = tmp_path / "assistant.db"
-    kv = SqliteKV(str(db_file))
+    with SqliteKV(str(db_file)) as kv:
+        items = [("a", "1"), ("b", "2"), ("c", "3")]
+        kv.set_many(items)
 
-    items = [("a", "1"), ("b", "2"), ("c", "3")]
-    kv.set_many(items)
-
-    for key, val in items:
-        assert kv.get(key) == val
+        for key, val in items:
+            assert kv.get(key) == val

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -16,3 +16,14 @@ def test_set_get(tmp_path):
     kv.set("foo", "bar")
     assert kv.get("foo") == "bar"
     assert kv.get("missing", "default") == "default"
+
+
+def test_set_many(tmp_path):
+    db_file = tmp_path / "assistant.db"
+    kv = SqliteKV(str(db_file))
+
+    items = [("a", "1"), ("b", "2"), ("c", "3")]
+    kv.set_many(items)
+
+    for key, val in items:
+        assert kv.get(key) == val

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.db import SqliteKV
+
+
+def test_set_get(tmp_path):
+    db_file = tmp_path / "assistant.db"
+    kv = SqliteKV(str(db_file))
+
+    # Ensure seed value is created
+    assert kv.get("last_history_id") == "0"
+
+    kv.set("foo", "bar")
+    assert kv.get("foo") == "bar"
+    assert kv.get("missing", "default") == "default"


### PR DESCRIPTION
## Summary
- implement `SqliteKV` key-value store using SQLite
- expose `src` as a package
- add unit test for `SqliteKV`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870383b63c483249fa6f8ee54ea7ee7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a persistent key-value store backed by SQLite for managing application state.
* **Tests**
  * Added tests to verify the correct behavior of the new key-value store, including set/get operations and batch updates.
* **Documentation**
  * Added a package-level description for the core module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->