### PR TITLE
Implement email importance classifier

### DIFF
--- a/data/vip_addresses.json
+++ b/data/vip_addresses.json
@@ -1,0 +1,1 @@
+["boss@example.com", "ceo@example.com"]

--- a/src/email_utils.py
+++ b/src/email_utils.py
@@ -1,0 +1,51 @@
+"""Utility functions for classifying email importance."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+VIP_PATH = Path("data/vip_addresses.json")
+
+
+def _load_vip_addresses() -> set[str]:
+    """Load VIP email addresses from :data:`VIP_PATH`."""
+    if VIP_PATH.exists():
+        with open(VIP_PATH, "r", encoding="utf-8") as f:
+            return set(json.load(f))
+    return set()
+
+
+VIP_ADDRESSES = _load_vip_addresses()
+
+
+def classify_importance(msg: Dict[str, Any]) -> str:
+    """Classify a Gmail message by importance level.
+
+    Parameters
+    ----------
+    msg : dict
+        Gmail API message resource containing ``labelIds`` and ``payload``.
+
+    Returns
+    -------
+    str
+        One of ``"vip"``, ``"promo"``, ``"newsletter"`` or ``"other"``.
+    """
+
+    headers = {
+        h.get("name"): h.get("value")
+        for h in msg.get("payload", {}).get("headers", [])
+        if isinstance(h, dict)
+    }
+    from_addr = headers.get("From", "")
+    labels = set(msg.get("labelIds", []))
+
+    if from_addr in VIP_ADDRESSES or "\\Starred" in labels:
+        return "vip"
+    if "CATEGORY_PROMOTIONS" in labels:
+        return "promo"
+    if "List-Id" in headers:
+        return "newsletter"
+    return "other"

--- a/tests/test_email_utils.py
+++ b/tests/test_email_utils.py
@@ -1,0 +1,61 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.email_utils import classify_importance
+
+
+VIP_MSG = {
+    "labelIds": [],
+    "payload": {
+        "headers": [
+            {"name": "From", "value": "boss@example.com"},
+        ]
+    },
+}
+
+STARRED_MSG = {
+    "labelIds": ["\\Starred"],
+    "payload": {"headers": []},
+}
+
+PROMO_MSG = {
+    "labelIds": ["CATEGORY_PROMOTIONS"],
+    "payload": {"headers": []},
+}
+
+NEWSLETTER_MSG = {
+    "labelIds": [],
+    "payload": {
+        "headers": [
+            {"name": "From", "value": "news@example.com"},
+            {"name": "List-Id", "value": "<news.list.example.com>"},
+        ]
+    },
+}
+
+OTHER_MSG = {
+    "labelIds": [],
+    "payload": {"headers": []},
+}
+
+
+def test_classify_vip_sender():
+    assert classify_importance(VIP_MSG) == "vip"
+
+
+def test_classify_vip_starred():
+    assert classify_importance(STARRED_MSG) == "vip"
+
+
+def test_classify_promo():
+    assert classify_importance(PROMO_MSG) == "promo"
+
+
+def test_classify_newsletter():
+    assert classify_importance(NEWSLETTER_MSG) == "newsletter"
+
+
+def test_classify_other():
+    assert classify_importance(OTHER_MSG) == "other"


### PR DESCRIPTION
## Summary
- add `src/email_utils.py` with `classify_importance`
- include a sample VIP address list
- test classification for vip, promo, newsletter and other emails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687045e993d483248e7068974024cf7d