### PR TITLE
Add Gmail history fetch utility

### DIFF
--- a/src/tools/email/__init__.py
+++ b/src/tools/email/__init__.py
@@ -2,4 +2,44 @@ from .find_contacts import find_contact_email
 from .read_emails import read_emails
 from .send_email import send_email
 
-__all__ = ['find_contact_email', 'read_emails', 'send_email']
+from typing import List, Dict
+
+__all__ = ['find_contact_email', 'read_emails', 'send_email', 'fetch_new_messages']
+
+
+def fetch_new_messages(service, history_id: str) -> List[Dict]:
+    """Fetch Gmail messages newer than a specific history ID."""
+    messages = []
+    message_ids = set()
+    page_token = None
+
+    while True:
+        kwargs = {'userId': 'me', 'startHistoryId': history_id}
+        if page_token:
+            kwargs['pageToken'] = page_token
+        response = (
+            service.users()
+            .history()
+            .list(**kwargs)
+            .execute()
+        )
+        for record in response.get('history', []):
+            for msg in record.get('messages', []):
+                msg_id = msg.get('id')
+                if msg_id:
+                    message_ids.add(msg_id)
+        page_token = response.get('nextPageToken')
+        if not page_token:
+            break
+
+    for msg_id in message_ids:
+        msg = (
+            service.users()
+            .messages()
+            .get(userId='me', id=msg_id, format='full')
+            .execute()
+        )
+        messages.append(msg)
+
+    messages.sort(key=lambda m: int(m.get('internalDate', '0')))
+    return messages

--- a/tests/test_fetch_new_messages.py
+++ b/tests/test_fetch_new_messages.py
@@ -1,0 +1,53 @@
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.tools.email import fetch_new_messages
+
+
+def make_service(history_responses, message_map):
+    service = Mock()
+    users = service.users.return_value
+
+    history = users.history.return_value
+    list_call = history.list.return_value
+    list_call.execute.side_effect = history_responses
+
+    messages = users.messages.return_value
+
+    def get_side_effect(userId, id, format):
+        resp = message_map[id]
+        call = Mock()
+        call.execute.return_value = resp
+        return call
+
+    messages.get.side_effect = get_side_effect
+    return service
+
+
+def test_fetch_new_messages_pagination_and_sorting():
+    history_responses = [
+        {
+            'history': [{'messages': [{'id': '1'}, {'id': '2'}]}],
+            'nextPageToken': 't1',
+        },
+        {
+            'history': [{'messages': [{'id': '2'}, {'id': '3'}]}]
+        },
+    ]
+
+    message_map = {
+        '1': {'id': '1', 'internalDate': '100'},
+        '2': {'id': '2', 'internalDate': '50'},
+        '3': {'id': '3', 'internalDate': '150'},
+    }
+
+    service = make_service(history_responses, message_map)
+
+    messages = fetch_new_messages(service, '10')
+    ids = [m['id'] for m in messages]
+
+    assert ids == ['2', '1', '3']
+


### PR DESCRIPTION
## Summary
- add `fetch_new_messages` in `src/tools/email/__init__.py`
- implement pagination, deduplication and sorting of Gmail messages
- add unit test using `unittest.mock`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687045c0c5e883248713e9db907ac026