### PR TITLE
Implement Telegram email push helper

### DIFF
--- a/src/channels/telegram.py
+++ b/src/channels/telegram.py
@@ -1,8 +1,10 @@
 import os
 import asyncio
-from telegram import Bot, Update
+from telegram import Bot, Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.constants import ParseMode
 from telegram.error import TelegramError
+
+import config
 
 
 class TelegramChannel:
@@ -37,3 +39,42 @@ class TelegramChannel:
             return new_messages
         except TelegramError as e:
             return f"Failed to retrieve messages: {str(e)}"
+
+
+def push_email(msg, kind):
+    """Push a Gmail message to the configured Telegram user.
+
+    Parameters
+    ----------
+    msg : dict
+        Message object returned by the Gmail API.
+    kind : str
+        Classification of the email (unused).
+    """
+
+    headers = {
+        h.get("name"): h.get("value")
+        for h in msg.get("payload", {}).get("headers", [])
+        if isinstance(h, dict)
+    }
+    subject = headers.get("Subject", "(no subject)")
+    from_addr = headers.get("From", "(unknown)")
+
+    body = msg.get("snippet", "")[:200]
+    md = f"*{subject}* \u00b7 _{from_addr}_ \u00b7 {body}"
+
+    buttons = [
+        [InlineKeyboardButton("Draft Reply", callback_data=f"draft:{msg.get('id')}")]
+    ]
+
+    parts = msg.get("payload", {}).get("parts", [])
+    if any(p.get("mimeType") == "text/calendar" for p in parts):
+        buttons.append([
+            InlineKeyboardButton("Yes", callback_data=f"rsvp:{msg.get('id')}:yes"),
+            InlineKeyboardButton("No", callback_data=f"rsvp:{msg.get('id')}:no"),
+            InlineKeyboardButton("Maybe", callback_data=f"rsvp:{msg.get('id')}:maybe"),
+        ])
+
+    ikb = InlineKeyboardMarkup(buttons)
+    bot = Bot(token=os.getenv("TELEGRAM_TOKEN"))
+    bot.send_message(chat_id=config.USER_ID, text=md, reply_markup=ikb)


### PR DESCRIPTION
## Summary
- extend Telegram channel utilities to format and push emails
- show subject, sender, and partial body with action buttons

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langsmith')*

------
https://chatgpt.com/codex/tasks/task_e_687047adc7d483248f51a7fa6eaab407