### PR TITLE
Add Gmail polling service

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,5 @@ selenium
 webdriver_manager
 html2text
 bs4
+langchain-core
+pytest-asyncio

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,51 @@
+import asyncio
+from googleapiclient.discovery import build
+
+from .db import SqliteKV
+from .channels.telegram import TelegramChannel
+from .email_utils import classify_importance
+from .tools.email import fetch_new_messages
+from .utils import get_credentials
+
+# Globals initialised in ``main``
+gmail_service = None
+db = SqliteKV()
+
+
+async def poll_gmail():
+    """Continuously poll Gmail for new messages."""
+    try:
+        while True:
+            last = db.get("last_history_id")
+            msgs = fetch_new_messages(gmail_service, last)
+            for m in msgs:
+                kind = classify_importance(m)
+                if kind == "vip":
+                    TelegramChannel.push_email(m, kind)
+            if msgs:
+                db.set("last_history_id", msgs[-1]["historyId"])
+            await asyncio.sleep(60)
+    except asyncio.CancelledError:
+        pass
+
+
+def main() -> None:
+    """Entry point for the polling service."""
+    global gmail_service
+    creds = get_credentials()
+    gmail_service = build("gmail", "v1", credentials=creds)
+
+    loop = asyncio.get_event_loop()
+    task = loop.create_task(poll_gmail())
+    try:
+        loop.run_until_complete(task)
+    except KeyboardInterrupt:
+        task.cancel()
+        loop.run_until_complete(task)
+    finally:
+        loop.close()
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/channels/telegram.py
+++ b/src/channels/telegram.py
@@ -37,3 +37,15 @@ class TelegramChannel:
             return new_messages
         except TelegramError as e:
             return f"Failed to retrieve messages: {str(e)}"
+
+    @staticmethod
+    def push_email(msg, kind):
+        """Send a formatted email notification via Telegram."""
+        headers = {
+            h.get("name"): h.get("value")
+            for h in msg.get("payload", {}).get("headers", [])
+            if isinstance(h, dict)
+        }
+        subject = headers.get("Subject", "(no subject)")
+        body = f"*{kind.upper()} email*\n{subject}"
+        TelegramChannel().send_message(body)

--- a/tests/test_poll_gmail.py
+++ b/tests/test_poll_gmail.py
@@ -1,0 +1,41 @@
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+import src.app as app
+
+
+@pytest.mark.asyncio
+async def test_poll_gmail_pushes_vip(monkeypatch):
+    msgs = [{"id": "1", "historyId": "10"}]
+
+    monkeypatch.setattr(app, "gmail_service", object())
+
+    fetch = lambda service, last: msgs
+    monkeypatch.setattr(app, "fetch_new_messages", fetch)
+
+    classify = lambda m: "vip"
+    monkeypatch.setattr(app, "classify_importance", classify)
+
+    pushed = []
+
+    def push_email(msg, kind):
+        pushed.append((msg, kind))
+
+    monkeypatch.setattr(app.TelegramChannel, "push_email", push_email)
+
+    db = MagicMock()
+    db.get.return_value = "0"
+    monkeypatch.setattr(app, "db", db)
+
+    async def fake_sleep(_):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(app.asyncio, "sleep", fake_sleep)
+
+    await app.poll_gmail()
+
+    assert pushed == [(msgs[0], "vip")]
+    db.set.assert_called_with("last_history_id", "10")
+


### PR DESCRIPTION
## Summary
- implement async Gmail polling in `src/app.py`
- support email push messages in `TelegramChannel`
- test Gmail polling logic
- include missing dependencies for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687047a3d45c832492da1038e007732c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an asynchronous Gmail polling service that classifies incoming emails and pushes VIP messages to a Telegram channel.

* **Tests**
  * Added an asynchronous test to verify that VIP emails are correctly pushed to Telegram during polling.

* **Chores**
  * Updated dependencies by adding `langchain-core` and `pytest-asyncio` to the requirements.

* **Style**
  * Removed an unnecessary blank line in the Telegram channel message receiver for improved code cleanliness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->