### PR TITLE
Add KVStore abstraction and backend factory

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -3,7 +3,7 @@ import time
 from apscheduler.schedulers.background import BackgroundScheduler
 from googleapiclient.discovery import build
 
-from .db import SqliteKV
+from .db import get_db
 from .channels.telegram import TelegramChannel
 from .email_utils import classify_importance
 from .tools.email import fetch_new_messages
@@ -12,7 +12,7 @@ from . import digest
 
 # Globals initialised in ``main``
 gmail_service = None
-db = SqliteKV()
+db = get_db()
 scheduler = BackgroundScheduler()
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -3,3 +3,4 @@ import os
 """Configuration constants for Telegram integration."""
 
 USER_ID = os.getenv("CHAT_ID", "")
+APP_DB_BACKEND = os.getenv("APP_DB_BACKEND", "sqlite")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -21,7 +21,7 @@ def test_set_many(tmp_path):
     db_file = tmp_path / "assistant.db"
     with SqliteKV(str(db_file)) as kv:
         items = [("a", "1"), ("b", "2"), ("c", "3")]
-        kv.set_many(items)
+        kv.transaction(items)
 
         for key, val in items:
             assert kv.get(key) == val


### PR DESCRIPTION
## Summary
- create an abstract `KVStore` interface and stub `CloudflareD1KV`
- implement `transaction` in `SqliteKV`
- add `get_db()` factory using `APP_DB_BACKEND`
- expose `APP_DB_BACKEND` in configuration
- update app to use `get_db`
- adjust DB tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687052d61ed88324a233c86fca1c26dd