### PR TITLE
Update README quick-start and env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,6 @@ SLACK_CHANNEL_ID=""          # Slack channel ID for targeting a specific channel
 TWILIO_ACCOUNT_SID=""        # Twilio Account SID for WhatsApp API authentication
 TWILIO_AUTH_TOKEN=""         # Twilio Auth Token for WhatsApp API authentication
 FROM_WHATSAPP_NUMBER="whatsapp:+"  # Twilio WhatsApp number for sending messages (in the format 'whatsapp:+<number>')
+
+# Database backend (leave as default for local SQLite)
+APP_DB_BACKEND="sqlite:///db/checkpoints.sqlite"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ This project provides a personal assistant agent that manages tasks related to y
 
 The personal assistant is a **hierarchical multi-agents** system with a **supervisor agent** (manager) and several sub-agents that handle specific tasks and tools for efficient task management.
 
+## Quick Start
+
+1. Copy `.env.example` to `.env` and set your **Telegram bot token** in `TELEGRAM_TOKEN`.
+2. Download your Gmail OAuth credentials and save the JSON file as `credentials.json` in the project root.
+3. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+4. Run the assistant:
+
+   ```bash
+   python app.py
+   ```
+
 ## Overview
 
 ### Main Agent: Assistant Manager
@@ -84,6 +100,18 @@ All the sub-agents report back to the Assistant Manager after completing their r
 4.  **Set up environment variables:**
 
     Create a `.env` file in the root directory of the project and add your API keys, see `.env.example` to know all the parameters you will need.
+
+### Environment variables
+
+| Name | Description |
+| ---- | ----------- |
+| `OPENAI_API_KEY` | API key for your preferred LLM provider. |
+| `TELEGRAM_TOKEN` | Token for your Telegram bot. |
+| `GMAIL_MAIL` | Gmail address used by the assistant. |
+| `GMAIL_APP_PASSWORD` | App password or OAuth token for Gmail. |
+| `APP_DB_BACKEND` | Database URL, default `sqlite:///db/checkpoints.sqlite`. |
+
+To use **Cloudflare D1** later, set `APP_DB_BACKEND` to your D1 connection string.
 
 5.  **Configure Google API credentials:**
 


### PR DESCRIPTION
## Summary
- add quick-start section describing minimal setup
- document important environment variables
- mention Cloudflare D1 usage
- add `APP_DB_BACKEND` example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870549ab164832491d01bc593be94a6