### PR TITLE
Add Dockerfile for container builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-alpine
+WORKDIR /app
+COPY . .
+RUN apk add --no-cache build-base && \
+    pip install --no-cache-dir -r requirements.txt
+CMD ["python", "app.py"]


### PR DESCRIPTION
## Summary
- add a Dockerfile to build and run the assistant

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `docker build .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687054b7a07c8324bf8048643e875b74